### PR TITLE
Shared library under Linux is copied with symlinks

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -102,7 +102,7 @@ class VorbisConan(ConanFile):
             if self.settings.os == "Macos":
                 self.copy(pattern="*.a", dst="lib", keep_path=False)
             else:
-                self.copy(pattern="*.so*", dst="lib", keep_path=False)
+                self.copy(pattern="*.so*", dst="lib", keep_path=False, symlinks=True)
 
     def package_info(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
Symbolic links should be copied as symbolic links to avoid copies